### PR TITLE
feat: implement login response DTO and repository interface

### DIFF
--- a/lib/features/login/data/dto/response/login_response.dart
+++ b/lib/features/login/data/dto/response/login_response.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'login_response.freezed.dart';
+part 'login_response.g.dart';
+
+@freezed
+abstract class LoginResponse with _$LoginResponse {
+  const factory LoginResponse({
+    @JsonKey(name: "status") required String status,
+    @JsonKey(name: "data") required LoginData data,
+  }) = _LoginResponse;
+
+  factory LoginResponse.fromJson(Map<String, dynamic> json) =>
+      _$LoginResponseFromJson(json);
+}
+
+@freezed
+abstract class LoginData with _$LoginData {
+  const factory LoginData({
+    @JsonKey(name: "accessToken") required String accessToken,
+    @JsonKey(name: "refreshToken") required String refreshToken,
+  }) = _LoginData;
+
+  factory LoginData.fromJson(Map<String, dynamic> json) =>
+      _$LoginDataFromJson(json);
+}

--- a/lib/features/login/data/dto/response/login_response.freezed.dart
+++ b/lib/features/login/data/dto/response/login_response.freezed.dart
@@ -1,0 +1,305 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'login_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$LoginResponse {
+
+@JsonKey(name: "status") String get status;@JsonKey(name: "data") LoginData get data;
+/// Create a copy of LoginResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LoginResponseCopyWith<LoginResponse> get copyWith => _$LoginResponseCopyWithImpl<LoginResponse>(this as LoginResponse, _$identity);
+
+  /// Serializes this LoginResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginResponse&&(identical(other.status, status) || other.status == status)&&(identical(other.data, data) || other.data == data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,data);
+
+@override
+String toString() {
+  return 'LoginResponse(status: $status, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LoginResponseCopyWith<$Res>  {
+  factory $LoginResponseCopyWith(LoginResponse value, $Res Function(LoginResponse) _then) = _$LoginResponseCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "status") String status,@JsonKey(name: "data") LoginData data
+});
+
+
+$LoginDataCopyWith<$Res> get data;
+
+}
+/// @nodoc
+class _$LoginResponseCopyWithImpl<$Res>
+    implements $LoginResponseCopyWith<$Res> {
+  _$LoginResponseCopyWithImpl(this._self, this._then);
+
+  final LoginResponse _self;
+  final $Res Function(LoginResponse) _then;
+
+/// Create a copy of LoginResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? data = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as LoginData,
+  ));
+}
+/// Create a copy of LoginResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LoginDataCopyWith<$Res> get data {
+  
+  return $LoginDataCopyWith<$Res>(_self.data, (value) {
+    return _then(_self.copyWith(data: value));
+  });
+}
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _LoginResponse implements LoginResponse {
+  const _LoginResponse({@JsonKey(name: "status") required this.status, @JsonKey(name: "data") required this.data});
+  factory _LoginResponse.fromJson(Map<String, dynamic> json) => _$LoginResponseFromJson(json);
+
+@override@JsonKey(name: "status") final  String status;
+@override@JsonKey(name: "data") final  LoginData data;
+
+/// Create a copy of LoginResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LoginResponseCopyWith<_LoginResponse> get copyWith => __$LoginResponseCopyWithImpl<_LoginResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$LoginResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LoginResponse&&(identical(other.status, status) || other.status == status)&&(identical(other.data, data) || other.data == data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,data);
+
+@override
+String toString() {
+  return 'LoginResponse(status: $status, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LoginResponseCopyWith<$Res> implements $LoginResponseCopyWith<$Res> {
+  factory _$LoginResponseCopyWith(_LoginResponse value, $Res Function(_LoginResponse) _then) = __$LoginResponseCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: "status") String status,@JsonKey(name: "data") LoginData data
+});
+
+
+@override $LoginDataCopyWith<$Res> get data;
+
+}
+/// @nodoc
+class __$LoginResponseCopyWithImpl<$Res>
+    implements _$LoginResponseCopyWith<$Res> {
+  __$LoginResponseCopyWithImpl(this._self, this._then);
+
+  final _LoginResponse _self;
+  final $Res Function(_LoginResponse) _then;
+
+/// Create a copy of LoginResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? data = null,}) {
+  return _then(_LoginResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as LoginData,
+  ));
+}
+
+/// Create a copy of LoginResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LoginDataCopyWith<$Res> get data {
+  
+  return $LoginDataCopyWith<$Res>(_self.data, (value) {
+    return _then(_self.copyWith(data: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$LoginData {
+
+@JsonKey(name: "accessToken") String get accessToken;@JsonKey(name: "refreshToken") String get refreshToken;
+/// Create a copy of LoginData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LoginDataCopyWith<LoginData> get copyWith => _$LoginDataCopyWithImpl<LoginData>(this as LoginData, _$identity);
+
+  /// Serializes this LoginData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginData&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,accessToken,refreshToken);
+
+@override
+String toString() {
+  return 'LoginData(accessToken: $accessToken, refreshToken: $refreshToken)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LoginDataCopyWith<$Res>  {
+  factory $LoginDataCopyWith(LoginData value, $Res Function(LoginData) _then) = _$LoginDataCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "accessToken") String accessToken,@JsonKey(name: "refreshToken") String refreshToken
+});
+
+
+
+
+}
+/// @nodoc
+class _$LoginDataCopyWithImpl<$Res>
+    implements $LoginDataCopyWith<$Res> {
+  _$LoginDataCopyWithImpl(this._self, this._then);
+
+  final LoginData _self;
+  final $Res Function(LoginData) _then;
+
+/// Create a copy of LoginData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? accessToken = null,Object? refreshToken = null,}) {
+  return _then(_self.copyWith(
+accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,refreshToken: null == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _LoginData implements LoginData {
+  const _LoginData({@JsonKey(name: "accessToken") required this.accessToken, @JsonKey(name: "refreshToken") required this.refreshToken});
+  factory _LoginData.fromJson(Map<String, dynamic> json) => _$LoginDataFromJson(json);
+
+@override@JsonKey(name: "accessToken") final  String accessToken;
+@override@JsonKey(name: "refreshToken") final  String refreshToken;
+
+/// Create a copy of LoginData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LoginDataCopyWith<_LoginData> get copyWith => __$LoginDataCopyWithImpl<_LoginData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$LoginDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LoginData&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,accessToken,refreshToken);
+
+@override
+String toString() {
+  return 'LoginData(accessToken: $accessToken, refreshToken: $refreshToken)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LoginDataCopyWith<$Res> implements $LoginDataCopyWith<$Res> {
+  factory _$LoginDataCopyWith(_LoginData value, $Res Function(_LoginData) _then) = __$LoginDataCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: "accessToken") String accessToken,@JsonKey(name: "refreshToken") String refreshToken
+});
+
+
+
+
+}
+/// @nodoc
+class __$LoginDataCopyWithImpl<$Res>
+    implements _$LoginDataCopyWith<$Res> {
+  __$LoginDataCopyWithImpl(this._self, this._then);
+
+  final _LoginData _self;
+  final $Res Function(_LoginData) _then;
+
+/// Create a copy of LoginData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? accessToken = null,Object? refreshToken = null,}) {
+  return _then(_LoginData(
+accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,refreshToken: null == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/login/data/dto/response/login_response.g.dart
+++ b/lib/features/login/data/dto/response/login_response.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_LoginResponse _$LoginResponseFromJson(Map<String, dynamic> json) =>
+    _LoginResponse(
+      status: json['status'] as String,
+      data: LoginData.fromJson(json['data'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$LoginResponseToJson(_LoginResponse instance) =>
+    <String, dynamic>{'status': instance.status, 'data': instance.data};
+
+_LoginData _$LoginDataFromJson(Map<String, dynamic> json) => _LoginData(
+  accessToken: json['accessToken'] as String,
+  refreshToken: json['refreshToken'] as String,
+);
+
+Map<String, dynamic> _$LoginDataToJson(_LoginData instance) =>
+    <String, dynamic>{
+      'accessToken': instance.accessToken,
+      'refreshToken': instance.refreshToken,
+    };

--- a/lib/features/login/repository/ilogin_repository.dart
+++ b/lib/features/login/repository/ilogin_repository.dart
@@ -1,0 +1,6 @@
+import 'package:auth_gorouter_riverpod/features/login/data/dto/request/login_request.dart';
+import 'package:auth_gorouter_riverpod/features/login/data/dto/response/login_response.dart';
+
+abstract interface class ILoginRepository {
+  Future<LoginResponse> login(LoginRequest request);
+}


### PR DESCRIPTION

/gemini
# 上下文
文件名：PR_LOGIN_DTO_REPO.md
創建於：[自動生成]
創建者：AI
關聯協議：RIPER-5 + 多維 + 代理協議 

# 任務描述
實作登入回應 DTO 及登入 repository 介面，確保登入功能資料結構與介面契約清晰，利於後續擴展與維護。

# 項目概述
本專案採用 Riverpod 狀態管理與 GoRouter 路由，聚焦於認證流程的模組化與可維護性。此次變更針對登入流程的資料結構與 repository 層進行優化，提升架構清晰度。

---
*以下部分由 AI 在協議執行過程中維護*
---

# 分析 (由 RESEARCH 模式填充)
- 新增 `LoginResponse` 及 `LoginData` 兩個資料類別，使用 freezed 生成不可變資料結構與 JSON 序列化。
- `LoginResponse` 對應 API 回傳的 status 與 data 欄位，`LoginData` 對應 accessToken 與 refreshToken。
- 自動生成 `login_response.freezed.dart` 及 `login_response.g.dart`，分別負責不可變操作與 JSON 轉換。
- 新增 `ILoginRepository` 介面，定義 login 方法，參數為 `LoginRequest`，回傳 `LoginResponse`，確保登入流程的依賴反轉與測試友善。
- `LoginRequest` 已定義於 `data/dto/request/login_request.dart`，包含 email 與 password 欄位。

# 提議的解決方案 (由 INNOVATE 模式填充)
- 採用 freezed 產生 DTO，確保資料結構不可變且易於序列化/反序列化。
- 以 interface 隔離 repository 實作，利於 mock 與單元測試，並符合 clean architecture 原則。
- 所有自動生成檔案皆由工具維護，主程式僅需關注 DTO 與介面定義。

# 實施計劃 (由 PLAN 模式生成)
實施檢查清單：
1. 新增 `LoginResponse` 及 `LoginData` 於 `data/dto/response/login_response.dart`，並產生對應 freezed/json 檔案。
2. 新增 `ILoginRepository` 介面於 `repository/ilogin_repository.dart`，定義 login 方法簽名。
3. 確認 `LoginRequest` 結構正確，並於介面中引用。
4. 驗證自動生成檔案內容正確。

# 當前執行步驟 (由 EXECUTE 模式在開始執行某步驟時更新)
> 正在執行: "全部步驟已完成，等待審查"

# 任務進度 (由 EXECUTE 模式在每步完成後追加)
*   [自動生成]
    *   步驟：全部步驟
    *   修改：
        - 新增 `login_response.dart`、`login_response.freezed.dart`、`login_response.g.dart`
        - 新增 `ilogin_repository.dart`
    *   更改摘要：完成登入回應 DTO 與 repository interface 實作
    *   原因：依據登入流程設計，確保資料結構與介面契約明確
    *   阻礙：無
    *   用戶確認狀態：待確認

# 最終審查 (由 REVIEW 模式填充)
- 實作與計劃完全一致，所有 DTO 與介面定義皆符合 clean architecture 與專案規範。
- 無未報告偏差。
